### PR TITLE
Fix "cannot get the first element of beginless range" error

### DIFF
--- a/lib/yard/parser/ruby/ast_node.rb
+++ b/lib/yard/parser/ruby/ast_node.rb
@@ -271,7 +271,7 @@ module YARD
 
         # @return [Fixnum] the starting line number of the node
         def line
-          line_range && line_range.first
+          line_range && line_range.begin || 1
         end
 
         # @return [String] the first line of source represented by the node.
@@ -345,8 +345,8 @@ module YARD
           elsif !children.empty?
             f = children.first
             l = children.last
-            self.line_range = Range.new(f.line_range.first, l.line_range.last)
-            self.source_range = Range.new(f.source_range.first, l.source_range.last)
+            self.line_range = Range.new(f.line_range.begin || 1, l.line_range.last)
+            self.source_range = Range.new(f.source_range.begin || 1, l.source_range.last)
           elsif @fallback_line || @fallback_source
             self.line_range = @fallback_line
             self.source_range = @fallback_source


### PR DESCRIPTION

This implements the fix suggested by @akimd [here](https://github.com/lsegal/yard/issues/1434#issuecomment-1087817139):

> I believe the proper fix is in lib/yard/parser/ruby/ast_node.rb to replace:
>
> ```ruby
> def line
>   line_range && line_range.first
> end
> ```
> by
> ```ruby
> def line
>   line_range && line_range.begin
> end
> ```
> since begin always returns the "first" element, as nil if it does not exist (while first dies if begin is nil).
>
> However in that case yardoc dies farther:
> ```
> /opt/local/lib/ruby3.1/gems/3.1.0/gems/yard-0.9.27/lib/yard/parser/ruby/ruby_parser.rb:624:in `block in insert_comments': undefined method `-' for nil:NilClass (NoMethodError)
>
>             ((node.line - 1).downto(node.line - 2).to_a + [node.line]).each do |line|
>                         ^
> 	from /opt/local/lib/ruby3.1/gems/3.1.0/gems/yard-0.9.27/lib/yard/parser/ruby/ast_node.rb:212:in `traverse'
> 	from /opt/local/lib/ruby3.1/gems/3.1.0/gems/yard-0.9.27/lib/yard/parser/ruby/ruby_parser.rb:615:in `insert_comments'
> ```
> so it looks like after all it does not like line to return nil, contrary to what the && seems to imply. So I made it
> ```ruby
> def line
>    line_range && line_range.begin || 1
> end
> ```
> and this time yardoc finishes properly.

Fixes lsegal/yard#1434.